### PR TITLE
Do not allow profile opening for the Server profile

### DIFF
--- a/src/lib/Post.svelte
+++ b/src/lib/Post.svelte
@@ -140,7 +140,7 @@
 		<button 
 			class="pfp" 
 			on:click={()=>{
-				if (post.user === "Notification" || post.user === "Announcement") return;
+				if (post.user === "Notification" || post.user === "Announcement" || post.user === "Server") return;
 				profileClicked.set(post.user);
 				page.set("profile");
 			}}


### PR DESCRIPTION
This PR disables (or removes) opening the Meower profile `Server`, as the account is used internally.