### PR TITLE
Disable bot/bot owner tags

### DIFF
--- a/src/lib/Post.svelte
+++ b/src/lib/Post.svelte
@@ -212,6 +212,7 @@
 					/>
 				{/if}
 
+				<!-- disabled until proper bot badges are added
 				{#if post.isvbot && !webhook}
 					<Badge
 						text="BOT"
@@ -223,10 +224,7 @@
 				{#if post.isuvbot && !webhook}
 					<Badge text="BOT" title="This bot has not been verified" />
 				{/if}
-
-				{#if post.ownsbot && !webhook}
-					<Badge text="BOT OWNER" />
-				{/if}
+				-->
 			</div>
 
 			<FormattedDate date={post.date} />

--- a/src/screens/Changelog.svelte
+++ b/src/screens/Changelog.svelte
@@ -13,7 +13,6 @@
 			Beta 4-style sidebar transition (except a bit less cooler due to the
 			logo not moving)
 		</li>
-		<li>Bot badges!</li>
 		<li>Work-in-progress search page</li>
 		<li>
 			Images now show up in posts (like [title: https://url]). There is an
@@ -36,6 +35,11 @@
 
 	<details>
 		<summary>Betas</summary>
+		<h3>Hotfix</h3>
+		<ul>
+			<li>Disable bot badges (they aren't officially supported, and the CL4 port will add them)</li>
+		</ul>
+		
 		<h3>Release</h3>
 		<ul>
 			<li>Banned status</li>

--- a/src/screens/Home.svelte
+++ b/src/screens/Home.svelte
@@ -44,8 +44,6 @@
 
 	let postInput;
 
-	let bots;
-
 	/**
 	 * Loads a page, with offset and overflow calculations.
 	 *
@@ -54,30 +52,6 @@
 	 */
 	async function loadPage(page) {
 		pageLoading = true;
-
-		// Load bot lists
-		if (!bots) {
-			bots = new Map();
-
-			const setBotStatuses = (text, status) => {
-				text.split(/\r?\n/).forEach(user => bots.set(user, status));
-			};
-
-			const uvbotlist = await fetch(
-				"https://raw.githubusercontent.com/MeowerBots/BotList/main/unverifed-bots.txt"
-			);
-			setBotStatuses(await uvbotlist.text(), "unverified");
-
-			const vbotlist = await fetch(
-				"https://raw.githubusercontent.com/MeowerBots/BotList/main/verified-bots.txt"
-			);
-			setBotStatuses(await vbotlist.text(), "verified");
-
-			const ubotlist = await fetch(
-				"https://raw.githubusercontent.com/MeowerBots/BotList/main/bot-owners.txt"
-			);
-			setBotStatuses(await ubotlist.text(), "owner");
-		}
 
 		if (page === undefined) {
 			posts = [];
@@ -127,9 +101,6 @@
 				for (const post of realPosts) {
 					posts.push({
 						id: id++,
-						isuvbot: bots.get(post.u) === "unverified",
-						isvbot: bots.get(post.u) === "verified",
-						ownsbot: bots.get(post.u) === "owner",
 						post_id: post.post_id,
 						user: post.u,
 						content: post.p,
@@ -180,9 +151,6 @@
 			if ($page === "home" && cmd.val.mode === 1) {
 				if (!(cmd.val.post_origin === "home")) return;
 				addPost({
-					isuvbot: bots.get(cmd.val.u) === "unverified",
-					isvbot: bots.get(cmd.val.u) === "verified",
-					ownsbot: bots.get(cmd.val.u) === "owner",
 					post_id: cmd.val._id,
 					user: cmd.val.u,
 					content: cmd.val.p,


### PR DESCRIPTION
Reasons why bot/bot owner tags should be disabled (at least until CL4 port where they are added officially):
* They are not officially supported currently
* CL4 port will add bot/verified bot tags officially
* The "BOT OWNER" tag pretty much falls under the "Meower Developer" badge which will be added when badges are officially added
* The way bot tags are stored is via a file and isn't properly added to a user's account, CL4 port will fix this by having user flags