### PR TITLE
Fix text overflows

### DIFF
--- a/src/lib/Container.svelte
+++ b/src/lib/Container.svelte
@@ -13,5 +13,6 @@
 		margin-bottom: 0.4em;
 		overflow-wrap: break-word;
 		position: relative;
+		overflow: auto;
 	}
 </style>


### PR DESCRIPTION
Resolves #84

In posts, group chat names and quotes.
Try with this character: `a`

## Images
![](https://user-images.githubusercontent.com/68464103/226521918-7d048710-686c-4aa3-a459-c775ab0ef9c9.png)
![](https://user-images.githubusercontent.com/68464103/226521936-799078db-02e0-49c5-a18c-bd3455bc15d6.png)
![](https://user-images.githubusercontent.com/68464103/226521965-293b55a8-5146-467b-bb80-462fc4b89235.png)