### PR TITLE
Revert "Bring back user list in home"

### DIFF
--- a/src/lib/ModPanel.svelte
+++ b/src/lib/ModPanel.svelte
@@ -12,6 +12,7 @@
 		user,
 	} from "./stores";
 	import {tick} from "svelte";
+	import {ulist} from "./stores.js";
 	import Container from "./Container.svelte";
 
 	let ipData = null;
@@ -85,6 +86,12 @@
 		no confirmation.<br />Also, performing an action on a user/post also
 		closes that user/post's report, if there's one.
 	</p>
+	<h2>User List</h2>
+	<Container>
+		There are currently {$ulist.length} users online{#if $ulist.length}{" "}({$ulist.join(
+				", "
+			)}){/if}.
+	</Container>
 	<h2>Get User Info</h2>
 	<form
 		on:submit|preventDefault={async e => {

--- a/src/screens/Home.svelte
+++ b/src/screens/Home.svelte
@@ -17,9 +17,7 @@
 			{:else if $ulist.length == 0}
 				Nobody is online.
 			{:else}
-				There are currently {$ulist.length} users online ({$ulist.join(
-					", "
-				)}).
+				There are currently {$ulist.length} users online.
 			{/if}
 		</div>
 	</Container>


### PR DESCRIPTION
Meower's ulist is a flawed idea that really acts as more of a moderation tool than anything else. The ulist has been used to cause issues in the past such as group chat spam, server strain, and more. Many of the use cases, such as seeing if bots are online, that are used by regular users can be done in other, better ways. This PR, which reverts #132, removes the ulist from home. This change DOES NOT remove the user count as the user count is fine and doesn't cause any privacy/security/server -related issues. This change also DOES NOT remove the ability of mods to view the ulist, instead moving it to the mod panel, where it should belong if its a mod only feature. Also see [this (team Discord)](https://canary.discord.com/channels/1085009166894108673/1085009167368081430/1091484871685320746)