### PR TITLE
Implement a patch

### DIFF
--- a/src/lib/PostList.svelte
+++ b/src/lib/PostList.svelte
@@ -156,8 +156,10 @@
 			if (!cmd.val) return;
 
 			const isGC = postOrigin !== "home";
+			if (cmd.val.mode === "delete") {
+				items = items.filter(post => post.post_id !== cmd.val.id);
+			}
 			if (!isGC || cmd.val.state === 2) {
-				if (!cmd.val.post_id) return;
 				if (cmd.val.post_origin !== postOrigin) return;
 
 				list.addItem({
@@ -198,9 +200,6 @@
 				cmd.val.mode !== "delete"
 			) {
 				playNotification();
-			}
-			if (cmd.val.mode === "delete") {
-				items = items.filter(post => post.post_id !== cmd.val.id);
 			}
 		});
 		destroy = () => clm.link.off(evId);


### PR DESCRIPTION
This fixes an issue with deleting posts

due to an oversight the original code would return the function before executing the event
lines in question: 
      if (!cmd.val.post_id) return;
      if (cmd.val.post_origin !== postOrigin) return;

fixed by moving the delete event to ontop of the first if statement and removing " if (!cmd.val.post_id) return;" as it was most likely for debugging purposes