### PR TITLE
fix: Bridged and webhook messages have an extra space at the start of the post content

### DIFF
--- a/src/lib/Post.svelte
+++ b/src/lib/Post.svelte
@@ -56,7 +56,7 @@
 
 		if (bridged || webhook) {
 			post.user = post.content.split(": ")[0];
-			post.content = post.content.slice(post.content.indexOf(": ") + 1);
+			post.content = post.content.slice(post.content.indexOf(": ") + 2);
 		}
 
 		// Match image syntax


### PR DESCRIPTION
^