### PR TITLE
Fix: Molbile settings regression

### DIFF
--- a/src/pages/settings.svelte
+++ b/src/pages/settings.svelte
@@ -1,5 +1,6 @@
 <!-- Brand new settings experience! -->
 <script>
+	import { width } from './../lib/responsiveness.js';
 	// @ts-nocheck
 
 	import {mobile} from "../lib/responsiveness.js";
@@ -280,5 +281,38 @@
 
 	.tabs-title {
 		margin: 0.25em;
+	}
+
+	@media (max-width: 800px) {
+		.settings {
+			flex-direction: column;
+		}
+		#tabs {
+			position: relative;
+			/* the tabs should take up minumum space */
+			min-height: fit-content;
+			height: fit-content;
+		}
+
+
+		#chat {
+			flex-grow: 0;
+			flex-shrink: 0;
+			flex-wrap: wrap;
+			width: 100%;
+			height: auto;
+			border: none;
+			border-top: solid 2px var(--orange);
+		}
+
+		:global(* .settings .profile-username) {
+
+			word-wrap:  break-word;
+			word-break: break-all;
+		}
+
+		:global(* .settings .profile-header-info) {
+			height: fit-content;
+		}
 	}
 </style>


### PR DESCRIPTION
Happened when the settings page was rewritten, moved to bottom like Github does when looking through a mobile browser

### Old
![image](https://github.com/meower-media-co/Meower-Svelte/assets/68120127/9498eb0c-ace1-43ac-a8e1-289c75f2a3e9)

### New 
![image](https://github.com/meower-media-co/Meower-Svelte/assets/68120127/6dc4623a-98f5-4942-82e4-2d9a34ad4e91)
